### PR TITLE
更新繁體中文翻譯

### DIFF
--- a/translations/values-zh-rTW/strings.xml
+++ b/translations/values-zh-rTW/strings.xml
@@ -12,11 +12,11 @@
   <string name="redo">重做</string>
   <string name="about">關於 | 幫助</string>
 
-  <string name="defaultContent">　　很高興見到你！\n　　這是一個快速的純文字編輯器，我們希望寫作能夠回到原本的樣子：<b>純粹、有安全感、隨時、絕對不遺失內容、具備良好的寫作體驗。</b>\n　　純純寫作在 Android 上實現了完美的行間距和段間距，它能夠使您的文字看起來更加舒適、清晰。同時，它還實現了「快速輸入列」和「格式化工具」，以及許多喜人的細節內容。\n　　最重要的，<b>在使用這個編輯器時，它將會保證您的內容永遠不會遺失，除非您主動將它清空。否則即使誤操作將文字刪除，或瞬間斷電，您仍然能夠從歷史記錄或備份中將它復原。</b>\n　　純純寫作還在順暢體驗上下了很多功夫，它擁有完美的鍵盤回應邏輯。使用純純寫作時，你能夠往下拖動快速輸入列來收起螢幕小鍵盤；能夠點擊文章某一行後，動態獲得合適的游標焦點定位；能夠在收起螢幕小鍵盤時，文章位置保持不動 … 許多這樣的細節內容，當你對比使用其他編輯器專案時，你才會發現純純寫作做得更加出色、順暢，細緻入微。\n　　蘊繁於簡。許多編輯器該有的功能，純純寫作也都沒有落下，比如 WebDAV 雲端備份、段首縮排、生成長圖片、指紋鎖定、Markdown、更換信紙、夜間模式、單詞輸入建議、打字機模式、復原、字數統計 等等。但即使這樣，純純寫作仍然保持了簡約的設計風格，遵循 Material Design 設計，並且它還有一個像是哆啦 A 夢 時光機 的圖示，寓意著「文字能夠連結過去，遙想未來」，也照應了純純寫作特別提供的「歷史記錄」功能。\n　　您能夠最快速度到達靈感頁面，能夠隨時隨地中斷和繼續寫作，這些我們都已經為您做好了。\n　　令人感到安心，順暢的寫作體驗，如你所願，這就是純純寫作，請享受寫作吧！</string>
+  <string name="defaultContent">　　很高興見到你！\n　　這是一個快速的純文字編輯器，我們希望寫作能夠回到原本的樣子：<b>純粹、有安全感、隨時、絕對不遺失內容、具備良好的寫作體驗。</b>\n　　純純寫作在 Android 上實現了完美的列間距和段落間距，它能夠使您的文字看起來更加舒適、清晰。同時，它還實現了「快速輸入列」和「格式化工具」，以及許多喜人的細節內容。\n　　最重要的，<b>在使用這個編輯器時，它將會保證您的內容永遠不會遺失，除非您主動將它清空。否則即使誤操作將文字刪除，或瞬間斷電，您仍然能夠從歷史記錄或備份中將它復原。</b>\n　　純純寫作還在順暢體驗上下了很多功夫，它擁有完美的鍵盤回應邏輯。使用純純寫作時，你能夠往下拖動快速輸入列來收起螢幕小鍵盤；能夠在點選文章某一列後，動態獲得合適的游標焦點定位；能夠在收起螢幕小鍵盤時，文章位置保持不動 … 許多這樣的細節內容，當你對比使用其他編輯器專案時，你才會發現純純寫作做得更加出色、順暢，細緻入微。\n　　蘊繁於簡。許多編輯器該有的功能，純純寫作也都沒有落下，比如 WebDAV 雲端備份、段首縮排、生成長圖片、指紋鎖定、Markdown、更換信紙、夜間模式、單詞輸入建議、打字機模式、復原、字數統計 等等。但即使這樣，純純寫作仍然保持了簡約的設計風格，遵循 Material Design 設計，並且它還有一個像是哆啦 A 夢 時光機 的圖示，寓意著「文字能夠連結過去，遙想未來」，也照應了純純寫作特別提供的「歷史記錄」功能。\n　　您能夠最快速度到達靈感頁面，能夠隨時隨地中斷和繼續寫作，這些我們都已經為您做好了。\n　　令人感到安心，順暢的寫作體驗，如你所願，這就是純純寫作，請享受寫作吧！</string>
   <string name="copyTitle">複製標題</string>
   <string name="copyContent">複製正文內容</string>
   <string name="clearThisContent"><b>清空</b>目前正文</string>
-  <string name="appPureMosaic">廣告:純純打碼</string>
+  <string name="appPureMosaic">廣告: 純純打碼</string>
   <string name="wordCountShort">字數</string>
   <string name="historyState">已儲存記錄</string>
   <string name="tipNeedFingerprint">需要指紋解鎖才能查看和編輯</string>
@@ -50,23 +50,23 @@
   <string name="format">格式</string>
   <string name="tipIndent">注意：段首縮排設定項變更不會改變已有文字</string>
   <string name="explanation">說明</string>
-  <string name="tipInsertBlankLines">這個設定項如果開啟，那麼在複製或發送正文內容時，會自動在發出的文字中每一處換行後 插入一行空行，因為在純純寫作之外，就沒有良好的段間距效果，所以以使用空行進行隔行。</string>
+  <string name="tipInsertBlankLines">開啟這個選項後，將在複製或發送正文內容時，自動在發出的文字中每一處換行後 插入一組空列，因為在純純寫作之外，就可能得不到良好的段落間距效果，所以以使用空列進行間隔。</string>
   <string name="deleteObsoleteFiles">刪除舊版歷史記錄檔案</string>
   <string name="dayNightMode">夜間模式</string>
   <string name="summaryPay">解鎖進階功能</string>
   <string name="summaryPaid">已解鎖進階功能</string>
-  <string name="tipSettingNotSupport">暫不能設定此項，之後版本即將支援</string>
+  <string name="tipSettingNotSupport">暫不能設定此項，將在之後版本提供支援</string>
   <string name="settings">設定</string>
   <string name="on">開啟</string>
   <string name="off">關閉</string>
   <string name="shortcutBar">快速輸入列</string>
-  <string name="insertBlankLinesWhenExporting">匯出時自動插入空行</string>
+  <string name="insertBlankLinesWhenExporting">匯出時自動插入空列</string>
   <string name="contentTextSize">正文字號、正文字型大小</string>
   <string name="iKnow">我知道了</string>
   <string name="noteShortcutCursorIndex">請移動內容中的游標位置來設定最終插入文章後游標的落點</string>
   <string name="indentShort">縮排</string>
   <string name="delete">刪除</string>
-  <string name="messageDeleteShortcut">點擊確定將刪除這個快速輸入項目</string>
+  <string name="messageDeleteShortcut">點按確定後將刪除這個快速輸入項目</string>
   <string name="promptShortcutTitle">簡短描述 (非必填)</string>
   <string name="promptShortcutContent">內容 (必填)</string>
   <string name="createShortcut">建立快速輸入項</string>
@@ -76,11 +76,11 @@
     <item>關閉夜間模式</item>
   </string-array>
   <string name="features">功能特性</string>
-  <string name="sendTextFailedForTooLarge">您的文字太長，無法直接發送到其他 App，已經轉而幫您把文字複製到您的剪貼簿了</string>
+  <string name="sendTextFailedForTooLarge">您的文字太長，無法直接發送到其他 App，已經轉而為您將文字複製到剪貼簿了</string>
   <string name="hasSavedToYourAlbum">已儲存到您的相簿</string>
-  <string name="previewAndExport">長圖片、PDF\n預覽 &amp; 儲存為…</string>
+  <string name="previewAndExport">長圖片\n預覽 &amp; 儲存為…</string>
   <string name="tipRequirePro">該功能需要購買進階版</string>
-  <string name="proReadMe">如果您覺得 純純寫作 很棒，希望它能更好地堅持開發下去，可否願意花一點點錢作為對於開發者的激勵？\n\n這能夠使我們一直堅持好的方向，良心的產品，同時激勵更多的獨立開發者。\n\n您可以點擊「Google Play」按鈕，開啟 Google Pay 支付。或者點擊「支付寶」購買啟用碼。作為回報，<b>付費後，將獲得「儲存為」和「自訂稿紙背景」等進階功能，對於不斷更新的進階內容不再收費</b>。\n純純寫作將因為您的支持而能夠不斷更新、完善，非常感謝！</string>
+  <string name="proReadMe">如果您覺得 純純寫作 很棒，希望它能更好地堅持開發下去，可否願意花一點點錢作為對開發人員的激勵？\n\n這能夠使我們一直堅持好的方向，做良心的產品，同時激勵更多的獨立開發人員。\n\n您可以點按「Google Play」按鈕，開啟 Google Pay 支付。或者點擊「支付寶」購買啟動序號。作為回報，<b>付費後，將獲得「儲存為」和「自訂稿紙背景」等進階功能，且對於之後不斷更新的進階內容不再進行收費</b>。\n純純寫作將因為您的支持而能夠不斷更新、完善，非常感謝！</string>
   <string name="preview">預覽</string>
   <string name="ok">好的</string>
   <string name="cancel">取消</string>
@@ -89,7 +89,7 @@
   <string name="update">更新</string>
   <string name="labelUpdate">有新版本的純純寫作 %1$s 可用</string>
   <string name="messageDeleteArticlesToTrash">您要刪除這些文章並將它們移入回收筒嗎？</string>
-  <string name="tipPurchasedStatusFailed">已購買。如果您的購買狀態沒有更新，請嘗試重新點擊 Pro 條目（這麼做不會重複扣除您的錢）</string>
+  <string name="tipPurchasedStatusFailed">已購買。如果您的購買狀態沒有更新，請嘗試重新點選 Pro 項目（這個操作不會重複產生費用）</string>
   <string name="createNew">建立新文章</string>
   <string name="autoLock">處於後台自動鎖定</string>
   <string name="enabled">啟用</string>
@@ -105,7 +105,7 @@
   <string name="summaryBackupToLocal">備份檔案將被儲存到 Documents/PureWriter/Backups</string>
   <string name="restoreBackup">復原備份</string>
   <string name="summaryRestoreTheBackup">備份檔案將從 Documents/PureWriter/Backups 和 Documents/PureWriter/Backups/Auto 和您的 GoogleDrive 或 WebDAV 或 Dropbox 雲端硬碟中存取</string>
-  <string name="tipBackupList">以下是備份檔案，點擊即可復原備份。\n<b>如果您想從 GoogleDrive/Dropbox/WebDAV 雲端取得備份，應該先登入你的 GoogleDrive/Dropbox/WebDAV 帳號後再進入此頁面！</b></string>
+  <string name="tipBackupList">以下是備份檔案，點選即可復原備份。\n<b>如果您想從 GoogleDrive/Dropbox/WebDAV 雲端硬碟取得備份，應先登入你的 GoogleDrive/Dropbox/WebDAV 帳號後再進入此頁面！</b></string>
   <string name="restoreSuccessful">復原備份成功</string>
   <string name="tipBackupNotExist">備份檔案不存在，請將備份檔案置於 Documents/PureWriter/Backups 並重試</string>
   <string name="wordCountMode">字數統計模式與<b>標點符號</b></string>
@@ -115,7 +115,7 @@
     <item><b>排除所有標點符號</b>、空白和換行字元</item>
   </string-array>
   <string name="fab">首頁浮動按鈕</string>
-  <string name="tipFab">提示：在首頁長按它可以臨時隱藏它</string>
+  <string name="tipFab">提示：在首頁對其長按可以臨時將其隱藏</string>
   <string name="tipCannotCreateNewWhenEmpty">標題和內容都為空時不能建立新文章，若您執意要建立，可透過右上角選單中的選項進行建立</string>
   <string name="more">更多</string>
   <string name="notSupportOpeningTheLink">不支援開啟此連結</string>
@@ -123,9 +123,9 @@
   <string name="formatterSpace">在中英文之間插入空白</string>
   <string name="formatterIndent">在段首插入縮排</string>
   <string name="formatterRemoveIndent">去除段首縮排</string>
-  <string name="formatterLineBreak">段與段之間保留一個空行</string>
-  <string name="formatterRemoveBreak">去除段與段之間多餘的空行</string>
-  <string name="titleAsAWordForACount">視一個單詞為一個計數</string>
+  <string name="formatterLineBreak">在段落與段落間保留一個空列</string>
+  <string name="formatterRemoveBreak">去除段落與段落間多餘的空列</string>
+  <string name="titleAsAWordForACount">視一個英文單字為單個計數</string>
   <string name="trash">回收筒</string>
   <string name="papers">稿紙</string>
   <string name="promptCustomPaper">顏色值或網址</string>
@@ -140,32 +140,32 @@
   <string name="summaryAutoBackup">檔案更改並退出時自動備份，最多可保留 25 個最新的備份檔案</string>
   <string name="migratingData">資料轉移</string>
   <string name="autoBackup">自動備份</string>
-  <string name="summaryDeleteObsoleteFiles">純純寫作現已使用應用程式私有目錄和資料庫儲存您的所有內容了。點擊此項可以刪除舊版純純寫作在 SD 卡留下的歷史記錄檔案</string>
+  <string name="summaryDeleteObsoleteFiles">純純寫作現已使用應用程式私有目錄和資料庫儲存您的所有內容了。點選此項可以刪除舊版純純寫作在記憶卡中留下的歷史記錄檔案</string>
   <string name="tipArticleDeleting">文章刪除中，暫不能進行操作</string>
   <string name="noHistory">無歷史記錄</string>
   <string name="keepScreenOn">螢幕不休眠</string>
-  <string name="gfmBreaksEnabled">支援以一個換行字元換行</string>
+  <string name="gfmBreaksEnabled">支援以一個換行字元進行換行</string>
   <string name="gfmBreaksDisabled">需要兩個換行字元才能真正在繪製時換行</string>
   <string name="wordCountOfThisBook">本書字數</string>
-  <string name="wordCountOfThisBookDescription">目前書籍所有篇章字數</string>
+  <string name="wordCountOfThisBookDescription">目前書籍所有篇章的字數</string>
   <string name="timeMachineGuide">這是什麼？ 你可以理解成一個聊天視窗，也可以理解成一個臨時記錄內容的地方，或類似 Google 助理。實際上，它有一個專門的名字，叫「時光機」。 很高興見到你！</string>
   <string name="copyDate">複製日期</string>
   <string name="books">書籍</string>
   <string name="defaultBook">預設書</string>
   <string name="summaryOfAbout">了解我們開發和設計這個應用程式的初衷和理念</string>
   <string name="createNewBook">建立新書</string>
-  <string name="emptyTip">尚未打開任何文章</string>
+  <string name="emptyTip">尚未開啟任何文章</string>
   <string name="name">名稱</string>
   <string name="optionalDescription">描述 (可不填)</string>
   <string name="createBookForDialogButton">建立書</string>
-  <string name="openSourceLicenses">開源許可證</string>
+  <string name="openSourceLicenses">開源許可</string>
   <string name="cannotDeleteNotEmptyBook">該書不為空，如需刪除，請逐一刪除或移出其包含的文章後重試</string>
   <string name="cannotDelete">無法刪除</string>
   <string name="moveTo">移動到</string>
   <string name="move">移動</string>
   <string name="timeMachine">時光機</string>
-  <string name="listFirst">啟動時打開清單</string>
-  <string name="booksFirst">啟動時打開書籍清單</string>
+  <string name="listFirst">啟動時開啟清單</string>
+  <string name="booksFirst">啟動時開啟書籍清單</string>
   <string name="language">語言</string>
   <string name="followSystem">跟隨系統</string>
   <string name="localPicture">本機圖片</string>
@@ -177,7 +177,7 @@
   <string name="plainText">純文字</string>
   <string name="mode">模式</string>
   <string name="tipHasNotPermissionWithAutoBackup">嘗試自動備份失敗，因為您沒有給予純純寫作儲存權限</string>
-  <string name="hideTitleBarWhenPreviewingMarkdown">預覽 Markdown 時隱藏標題欄</string>
+  <string name="hideTitleBarWhenPreviewingMarkdown">預覽 Markdown 時隱藏標題列</string>
   <string name="privacyPolicy">隱私政策</string>
   <string name="beforeRestoringYourBackup">復原備份之前</string>
   <string name="trashDescription">找回您刪除的文章</string>
@@ -186,7 +186,7 @@
     <item quantity="other">確定要刪除這 %d 條訊息嗎？</item>
   </plurals>
   <string name="trashFolderTip">您正處於回收筒資料夾中，該資料夾中無法建立新文章。</string>
-  <string name="tipLandscapeOrientation">橫向螢幕模式中請使用外接鍵盤</string>
+  <string name="tipLandscapeOrientation">橫向螢幕模式中請使用外掛式鍵盤</string>
   <string name="promptShortcutOrder">排序</string>
   <string name="editShortcut">編輯快速輸入項</string>
   <string name="backupSettingTitle">備份與雲端備份</string>
@@ -202,38 +202,38 @@
   <string name="noWebDavConfigForUploading">您的 WebDAV 設定不完整或不正確，請修改 WebDAV 設定後再嘗試上傳。</string>
   <string name="noWebDavConfig">您的 WebDAV 設定不完整或不正確。</string>
   <string name="uploadSuccessful">上傳成功</string>
-  <string name="fetchSuccessful">拉取成功</string>
-  <string name="messageUpload">純純寫作在您的雲端硬碟上建立了<b>一個固定檔案</b>，檔案名叫 <b>PureWriter.txt</b>，您可以點擊「確定」上傳目前文章的內容到這個固定檔案中，然後您便可以在其他裝置上編輯這個雲端檔案，之後您可以再將它的新內容拉取下來。\n\n請問您現在確定要將目前文章內容覆蓋寫入到您的這個雲端固定檔案嗎？</string>
+  <string name="fetchSuccessful">取得成功</string>
+  <string name="messageUpload">純純寫作在您的雲端硬碟上建立了<b>一個固定檔案</b>，檔案名叫 <b>PureWriter.txt</b>，您可以點選「確定」上傳目前文章的內容到這個固定檔案中，然後您便可以在其他裝置上編輯這個雲端檔案，之後您可以再取得其中的更新內容。\n\n請問您現在確定要將目前文章內容覆蓋寫入到您的這個雲端固定檔案嗎？</string>
   <string name="fixedSync">雲端存取</string>
-  <string name="bridgeUpload">雲端存取: 上傳</string>
-  <string name="bridgeDownload">雲端存取: 拉取</string>
+  <string name="bridgeUpload">雲端存取：上傳</string>
+  <string name="bridgeDownload">雲端存取：拉取</string>
   <string name="typewriterMode">打字機模式</string>
   <string name="edit">修改</string>
   <string name="editBook">修改書籍</string>
   <string name="shareText">推薦：純純寫作，一個令人感到安心、擁有歷史記錄、多重防止文章遺失功能，和許多寫作輔助的編輯器：https://writer.drakeet.com</string>
-  <string name="shareMessage">如果你喜歡和支持純純寫作，請幫忙點擊右側的分享按鈕與你的朋友推薦這個應用程式，這對於它來說意義重大，純純寫作將因為你的支持而能夠變得更好，並不斷開發、完善下去，非常感謝！\n\n了解更多關於純純寫作：https://writer.drakeet.com</string>
+  <string name="shareMessage">如果你喜歡和支持純純寫作，請幫忙點按右側的分享按鈕與你的朋友推薦這個應用程式，這對於它來說意義重大，純純寫作將因為你的支持而能夠變得更好，並不斷開發、完善下去，非常感謝！\n\n了解關於純純寫作的更多內容：https://writer.drakeet.com</string>
   <string name="wordCountLong">字數統計</string>
   <string name="wordCountOfCurrentArticle">目前文章字數統計</string>
   <string name="floatingWordCount">浮動字數統計</string>
-  <string name="tipFloatingWordCountDisabled">關閉懸浮字數統計後，您可以在文章列表中獲取字數統計。</string>
+  <string name="tipFloatingWordCountDisabled">關閉懸浮字數統計後，您仍可以前往文章清單中取得字數統計。</string>
   <string name="reduceDatabaseSize">資料庫檔案瘦身 ，刪除歷史記錄</string>
   <string name="deleteSuccessful">刪除完成</string>
   <string name="reduceDatabaseSizeMessage">刪除所有文章的歷史記錄。\n只是刪除歷史記錄，文章本身不會被刪除。</string>
   <string name="unlockPro">解鎖進階版</string>
   <string name="presetTitle1">純純寫作 - 願文字帶我們穿越時光，連接過去遙想未來</string>
-  <string name="presetContent1" tools:ignore="TypographyEllipsis">　　純純寫作是一款致力於提供 絕不遺失內容、快速、優秀寫作體驗 的 App。在 Google Play Store 翻看對於純純寫作來自全世界使用者的評論時，你能夠找到大量使用者對純純寫作的誇張讚美，比如「沒用過這麼好用的 App」、「最滿意的 App」、「愛死這個 App」、「一見傾心」... 作為這個應用程式的唯一開發者，真是特別欣慰...\n　　2017 年 6 月末的一天，在經歷過其他編輯器程式導致的各種文字遺失事件，以及體驗了各種不如意、粗糙的寫作產品後，我決心自己來開發這麼一款 讓人隨時隨地能夠獲得安心的寫作感覺、提供寫作輔助、並真正從寫作者角度出發進行設計和開發的應用程式。\n　　在此之前，我在業餘時間負責獨立為「字裡行間」應用程式開發一個新的編輯器。那時我們在富文字編輯器上花費了大量心血，雖然最終也沒能在 Android 上實現我們覺得滿意的高效能富文字編輯器，但這個過程中我發明了許多獨有的實用技術，這些技術用於開發一個純文字編輯器綽綽有餘。\n　　於是純純寫作誕生了，它一開始便在 Android 上實現了 完美的行間距和段間距 功能，做到了全系統相容，原生效能。這是純純寫作的獨有技術，除了微軟的 Office Word 你很難能夠再找到一款在手機上支援段間距和穩定行間距的編輯器。而 Office Word 的安裝套件體積是純純寫作的幾十倍。\n　　除了獨有的段間距，純純寫作一開始還提供了「啟動馬上進入編輯頁面」以及特有的「歷史記錄」功能。特別是歷史記錄功能，實際上作為一個寫作者，我深知歷史記錄功能實在太重要了，它能夠讓你擁有難得的安心、放心寫作的感覺，而且純純寫作做到了即使手機瞬間斷電關機，也能夠即時自動儲存，絕不遺失內容。這樣的好處是，大家可以隨時暫停和隨時繼續寫作，並且配合純純寫作的螢幕小鍵盤狀態記錄與復原，來回切換將令人感到特別順暢舒適。\n　　此外，純純寫作還支援「快速輸入列」和「格式化工具」，快速輸入列能夠讓使用者自訂快速詞語和短語；格式化面板則能夠幫助使用者快速調整文章格式，比如在中英文之間自動插入空白，或者自動進行縮排調整等等。\n　　在實現了這些顯著功能以外，純純寫作還在細節體驗上下了很多功夫，它擁有 完美的鍵盤回應邏輯。使用純純寫作時，你能夠往下快速滑動頁面或快速輸入列來收起輸入法小鍵盤；能夠點擊文章某一行後，動態獲得合適的游標焦點定位；能夠在收起螢幕小鍵盤時，文章位置保持不動 ... 許多這樣的細節內容，當你對比使用其他編輯器專案時，你才會發現純純寫作做得更加出色，細緻入微。\n　　至於一個編輯器該有的功能，純純寫作也都沒有落下，比如 自動段首縮排、生成長圖片、浮動字數統計、復原、Markdown、更換信紙、指紋鎖定、夜間模式、單詞輸入建議、快速滾動、匯出和發送檔案 等等。但即使這樣，純純寫作仍然保持了簡約、蘊繁於簡的設計風格，遵循 Material Design，並且我還為它畫了個像是機器貓 時光機 的圖示，寓意著「文字能夠連結過去，遙想未來」，也照應了純純寫作特別提供的「歷史記錄」功能。\n　　時至今日，純純寫作的開發工作已經有 7000 次程式碼提交了，程式碼變更十幾萬行。它花費了我幾乎所有的業餘時間，但很高興越來越多人告訴我他們對這個應用程式特別喜歡，相見恨晚；我也非常積極地與使用者交流，收集回饋，不斷完善。這令我感到前所未有的開心，想來自己做了一件很有意義並且值得長期投入的事情。\n　　感謝所有在這個過程支持和幫助過我的朋友，沒有你們，這個應用不能夠一步步做得更好，也不能夠長期不停地維護更新下去，真是太好了 ... 也因此今天我終於能夠寫這麼一篇文章來介紹純純寫作的初衷，和它的許多「特色功能」，希望能夠讓更多人認識到這個產品，願我們在人生歲月中，能夠記錄更多感動、留下更多回憶，願文字能夠帶我們穿越時光，連結過去，遙想未來。</string>
+  <string name="presetContent1" tools:ignore="TypographyEllipsis">　　純純寫作是一款致力於提供 絕不遺失內容、快速、優秀寫作體驗 的 App。在 Google Play Store 翻看對於純純寫作來自全世界使用者的評論時，你能夠找到大量使用者對純純寫作的誇張讚美，比如「沒用過這麼好用的 App」、「最滿意的 App」、「愛死這個 App」、「一見傾心」... 作為這個應用程式的唯一開發人員，真是特別欣慰...\n　　2017 年 6 月末的一天，在經歷過其他編輯器程式導致的各種文字遺失事件，以及體驗了各種不如意、粗糙的寫作產品後，我決心自己來開發這麼一款 讓人隨時隨地能夠獲得安心的寫作感覺、提供寫作輔助、並真正從寫作者角度出發進行設計和開發的應用程式。\n　　在此之前，我在業餘時間負責獨立為名為「字裡行間」的應用程式開發一個新的編輯器。那時我們在富文字編輯器上花費了大量心血，雖然最終也沒能在 Android 上實現我們覺得滿意的高效能富文字編輯器，但這個過程中我發明了許多獨有的實用技術，這些技術用於開發一個純文字編輯器綽綽有餘。\n　　於是純純寫作誕生了，它一開始便在 Android 上實現了 完美的列間距和段落間距 功能，做到了完整系統相容性和原生等級的高效能。這是純純寫作的獨有技術，除了微軟的 Office Word 你很難能夠再找到一款在手機上支援段落間距和穩定列間距的編輯器。而 Office Word 的安裝套件體積是純純寫作的幾十倍。\n　　除了獨有的段落間距，純純寫作一開始還提供了「啟動馬上進入編輯頁面」以及特有的「歷史記錄」功能。特別是歷史記錄功能，實際上作為一個寫作者，我深知歷史記錄功能實在太重要了，它能夠讓你擁有難得的安心、放心寫作的感覺，而且純純寫作做到了即使手機瞬間斷電關機，也能夠即時自動儲存，絕不遺失內容。這樣的好處是，大家可以隨時暫停和隨時繼續寫作，並且配合純純寫作的螢幕小鍵盤狀態記錄與復原，來回切換將令人感到特別順暢舒適。\n　　此外，純純寫作還支援「快速輸入列」和「格式化工具」，快速輸入列能夠讓使用者自訂快速詞語和短語；格式化面板則能夠幫助使用者快速調整文章格式，比如在中英文之間自動插入空白，或者自動進行縮排調整等等。\n　　在實現了這些顯著功能以外，純純寫作還在細節體驗上下了很多功夫，它擁有 完美的鍵盤回應邏輯。使用純純寫作時，你能夠往下快速滑動頁面或快速輸入列來收起輸入法小鍵盤；能夠在點選文章某一列後，動態獲得最合適的游標焦點定位；能夠在收起螢幕小鍵盤時，文章位置保持不動 ... 許多這樣的細節內容，當你在對比使用其他編輯器時，才會發現純純寫作做得更加出色，細緻入微。\n　　至於一個編輯器該有的功能，純純寫作也都沒有落下，比如 自動段首縮排、生成長圖片、浮動字數統計、復原、Markdown、更換信紙、指紋鎖定、夜間模式、單字輸入建議、快速滾動、匯出和發送檔案 等等。但即使這樣，純純寫作仍然保持了簡約、蘊繁於簡的設計風格，遵循 Material Design，並且我還為它畫了個像是機器貓 時光機 的圖示，寓意著「文字能夠連結過去，遙想未來」，也照應了純純寫作特別提供的「歷史記錄」功能。\n　　時至今日，純純寫作的開發工作已經有 7000 次程式碼提交了，程式碼變更也達到了十幾萬列。它花費了我幾乎所有的業餘時間，但很高興越來越多人告訴我他們對這個應用程式特別喜歡，相見恨晚；我也非常積極地與使用者交流，收集回饋，不斷完善。這令我感到前所未有的開心，想來自己做了一件很有意義並且值得長期投入的事情。\n　　感謝所有在這個過程支持和幫助過我的朋友，沒有你們，這個應用不能夠一步步做得更好，也不能夠長期不停地維護更新下去，真是太好了 ... 也因此今天我終於能夠寫這麼一篇文章來介紹純純寫作的初衷，和它的許多「特色功能」，希望能夠讓更多人認識到這個產品，願我們在人生歲月中，能夠記錄更多感動、留下更多回憶，願文字能夠帶我們穿越時光，連結過去，遙想未來。</string>
   <string name="presetTitle2">純純寫作 - 保護機制</string>
-  <string name="presetContent2">目前為止純純寫作保護文章避免遺失的防線有： \n1. 文章一旦變動就會觸發自動儲存，自動儲存時，若失敗則馬上警告使用者 \n2. 每隔 2 秒進行一次主動檢查文章是否正常存入資料庫、是否與資料庫內容匹配，若失敗則馬上警告使用者 \n3. 如果儲存失敗，則無法真正退出應用程式，此時按退出鍵等於按 Home 鍵，儘可能給予使用者手動儲存的機會 \n4. 每次切到背景或退出應用程式，如若文章有變化，則進行一次自動備份整個資料庫，備份內容可以隨時復原，復原之前會自動備份「復原之前」的內容以供放棄復原 \n5. 為每一篇文章提供歷史記錄、復原與重做 \n6. 提供回收筒，避免誤刪文章 \n7. 雲端備份，如果設定 WebDAV，則純純寫作會預設開啟雲端備份功能，自動將你的 db 資料庫檔案（包含全部文章）同步到雲端</string>
+  <string name="presetContent2">目前為止純純寫作保護文章避免遺失的防線有： \n1. 文章一經變動就會觸發自動儲存，若失敗將馬上警告使用者 \n2. 每隔 2 秒進行一次主動檢查文章是否正常存入資料庫、是否與資料庫內容匹配，若失敗將馬上警告使用者 \n3. 如果儲存失敗，則無法真正退出應用程式，此時按退出鍵等於按 Home 鍵（保留背景處理程序），儘可能給予使用者手動儲存的機會 \n4. 每次切到背景或退出應用程式，如若文章有變化，則進行一次自動備份完整資料庫，備份內容可以隨時復原，每次執行復原之前會自動備份「復原之前」的內容以供放棄復原 \n5. 為每一篇文章提供歷史記錄、復原與重做 \n6. 提供回收筒，避免誤刪文章 \n7. 雲端備份，如果設定 WebDAV，則純純寫作會預設開啟雲端備份功能，自動將你的 db 資料庫檔案（包含全部文章）同步到雲端</string>
   <string name="presetTitle3">關於純純寫作進階版</string>
-  <string name="presetContent3">如果你覺得 純純寫作 很棒，希望它能繼續堅持下去，可否願意花一點點錢作為對於開發者的激勵？ \n這能夠使我們一直堅持好的方向、良心的產品，同時激勵更多的獨立開發者。 \n您可以點擊右上角的設定頁面進入「解鎖純純寫作進階版功能」，作為回報，付費後，您將獲得「儲存為」和「自訂稿紙背景」等進階功能。 \n純純寫作也將因為您的支持而能夠不斷更新、完善，非常感謝！ \n如果您有任何問題或需求，也可以透過郵件聯絡我：drakeet@drakeet.com</string>
+  <string name="presetContent3">如果你覺得 純純寫作 很棒，希望它能繼續堅持下去，可否願意花一點點錢作為對於開發人員的激勵？ \n這能夠使我們一直堅持好的方向、良心的產品，同時激勵更多的獨立開發人員。 \n您可以點選右上角的設定頁面進入「解鎖純純寫作進階版功能」，作為回報，付費後，您將取得「儲存為」和「自訂稿紙背景」等進階功能。 \n純純寫作也將因為您的支持而能夠不斷更新、完善，非常感謝！ \n如果您有任何問題或需求，也可以透過郵件聯絡我：drakeet@drakeet.com</string>
   <string name="presetTitle4">純純寫作 - 隱私政策</string>
   <string name="presetContent4">純純寫作非常重視使用者的隱私保護，它絕不會收集您的任何隱私內容。\n另外，在未經允許或告知的情況下，純純寫作也絕不會修改或讀取您的剪貼簿內容。\n純純寫作申請了儲存空間權限，僅僅用於匯出檔案和進行自動備份，除此之外，它不會在未經允許或告知的情況下讀取或修改您外部儲存空間中的任何檔案。\n純純寫作支援雲端備份，它會預設使用 HTTPS 加密傳輸你的資料庫備份到你的 WebDAV 雲端硬碟，你的雲端備份只會存儲於你設定的雲端硬碟，它們絕不會被上傳到其它地方。</string>
   <string name="createAt">建立於</string>
   <string name="updatedAt">更新於</string>
   <string name="forcedBlackTextColor">強制黑色字型</string>
   <string name="forcedWhiteTextColor">強制白色字型</string>
-  <string name="paragraphSpacing">段間距</string>
-  <string name="onlyAvailableWhenParagraphOn">僅在開啟段間距時有效</string>
+  <string name="paragraphSpacing">段落間距</string>
+  <string name="onlyAvailableWhenParagraphOn">僅在開啟段落間距時有效</string>
   <string name="lowProfile">狀態列專注模式</string>
   <string name="chapters">篇章</string>
   <string name="sortTypeTitleUp">標題升序</string>
@@ -259,8 +259,8 @@
   <string name="needManualSortingTitle">需要切換到手動排序才能使用該功能</string>
   <string name="needManualSortingMessage">您想切換到手動排序嗎？</string>
   <string name="doubleClickToExitTip">再按一次返回鍵退出</string>
-  <string name="doubleClickToExit">雙擊返回鍵退出應用程式</string>
-  <string name="markdownCheckBoxTip">該選項是為 Markdown 提供的，勾選後，段間距和段首自動縮排都將會自動失效，如果您不熟悉 Markdown，建議您不要勾選它。\n\nMarkdown 是一種運用廣泛的標記性寫作語言，如果您有興趣，可以自行上網搜尋 Markdown 了解詳情。</string>
+  <string name="doubleClickToExit">點按兩次返回鍵退出應用程式</string>
+  <string name="markdownCheckBoxTip">該選項是為 Markdown 提供的，選取後段落間距和段首自動縮排都將會自動失效，如果您不熟悉 Markdown，建議您不要進行選取。\n\nMarkdown 是一種運用廣泛的標記性寫作語言，如果您有興趣，可以自行上網搜尋 Markdown 了解詳情。</string>
   <string name="unlockValidityPeriod">解鎖失效時間</string>
   <string name="unlockValidityPeriodSummary">%s\n提示：若按返回鍵退出應用則會立即鎖定</string>
   <string name="lockImmediatelyIfAway">離開時立即鎖定</string>
@@ -269,20 +269,20 @@
   <string name="appEmbeddedFont">純純寫作包含內建字型</string>
   <string name="noInternetConnection">沒有網路連線</string>
   <string name="cloudBackup">雲端備份</string>
-  <string name="cloudConnection">雲端連線類型（點擊此項可切換）</string>
+  <string name="cloudConnection">雲端連線類型（點選此項可切換）</string>
   <string name="signIn">登入</string>
   <string name="backupToLocalNow">立即備份到本機儲存空間</string>
   <string name="backupToCloudNow">立即備份到雲端網路硬碟</string>
   <string name="summaryBackupToCloud">如果您已設定雲端備份，備份檔案將存儲到您的雲端儲存空間</string>
-  <string name="lockFallback">如果您始終無法解除鎖定，您可以進入您的手機系統設定，移除您的所有指紋，然後重新打開純純寫作即可。</string>
-  <string name="smoothScrollerTitle">順滑的聚焦文字行滾動動畫</string>
-  <string name="tipSmoothScrolling">如果開啟這個選項，當你點擊正文的某一行，若有必要，編輯器會順滑地滾動頁面到該行。如果這個選項關閉，則會瞬間跳躍到該行。\n滾動動畫可能在一些裝置上表現不佳，因此如果你感覺到 lag，請關閉這個選項。</string>
+  <string name="lockFallback">如果您始終無法解除鎖定，您可以進入您的手機系統設定，移除您的所有指紋，然後重新開啟純純寫作即可。</string>
+  <string name="smoothScrollerTitle">順滑的聚焦文字列滾動動畫</string>
+  <string name="tipSmoothScrolling">開啟這個選項後，當你點選正文的某一列，若有必要，編輯器會順滑地滾動頁面至該列。這個選項保持關閉時，則會瞬間跳躍到該列。\n滾動動畫可能在一些裝置上表現不佳，因此如果你感覺到 lag，請關閉這個選項。</string>
   <string name="defaultMessageUpdateApk">這是一個重要的版本，請儘快更新到這個版本</string>
   <string name="readme">您已開啟了純純寫作新的 Material Design 2 設計。\n\nMaterial Design 2 帶來了新的全螢幕沉浸稿紙和透明化頂部列，更加精緻多彩。\n\n但與此同時，新的設計可能存在諸多問題，因此這個特性作為純純寫作的一個實驗性功能，它可能存在一些 UI 視覺上的問題。另外，作為純純寫作的作者，相對來說，我更喜歡純純寫作預設原版設計，它更加耐看和令人專注文字內容，因此這個主題實際上是應少數使用者強烈要求而特地開發的，它給開發者造出了額外的開發成本，能夠提供出來實屬不易，而且由於需要兼顧兩套設計和主題，開發者的工作可能會成倍增加。\n\n由此，如果開啟 Material Design 2 後純純寫作將採用強制收費方式，但您仍然可以有許多時間去體驗並作出最終付費決定。請儘量支持它，如果經過統計發現最終願意付費的使用者比例很少，開發者可能會復原或停止提供 Material Design 2。您一旦開啟 Material Design 2，將視為預設同意此內容。\n\n謝謝大家！我會竭盡全力提供一個越來越好的純純寫作，請享用！</string>
   <string name="lowFreeStorageSpaceWarning">您的手機剩餘儲存空間只有 %1$d MB, 這可能導致純純寫作儲存或備份失敗，請務必清理留出 %2$d MB 以上空間後再使用純純寫作！</string>
   <string name="pureWriterBBS">純純寫作論壇</string>
   <string name="replaceConfirmMessage">你確定要取代 %d 處內容嗎？</string>
-  <string name="tipUndoReplace">如果取代後想要反悔：\n* 你可以進入純純寫作 - 設定 - 備份 - 復原備份，點擊上一個備份復原到取代之前的內容。\n* 如果你僅僅是取代了目前篇章，則可以透過右上角選單進入歷史記錄頁面，復原到取代之前的內容。</string>
+  <string name="tipUndoReplace">如果取代後想要反悔：\n* 你可以進入純純寫作 - 設定 - 備份 - 復原備份，點選上一個備份復原到取代之前的內容。\n* 如果你僅僅是取代了目前篇章，則可以透過右上角選單進入歷史記錄頁面，復原到取代之前的內容。</string>
   <string name="findReplace">尋找 &amp; 取代</string>
   <string name="replace">取代</string>
   <string name="find">尋找</string>
@@ -295,22 +295,22 @@
   <string name="title">標題</string>
   <string name="content">正文</string>
   <string name="inverseAll">反選</string>
-  <string name="webDavAccountError">WebDAV 帳號訊息有誤，無法啟用雲端備份</string>
+  <string name="webDavAccountError">WebDAV 帳號資訊有誤，無法啟用雲端備份</string>
   <string name="fileAlreadyExistsInDirectory">該檔案已經存在於你的檔案目錄中了</string>
   <string name="overwrite">覆蓋</string>
   <string name="doNotOverwrite">不覆蓋</string>
   <string name="signOut">登出</string>
-  <string name="changeAccount">更換帳號</string>
+  <string name="changeAccount">變更帳號</string>
   <string name="scrollToHideTopBar">滾動以隱藏頂部列</string>
   <string name="doNotOperate">請不要在此過程中切換或修改文章！</string>
   <string name="aboutBackup"><b>《使用者須知：關於備份》</b></string>
-  <string name="backupReadme">純純寫作支援本機備份和雲端備份，本機備份是自動進行的，當您重裝純純寫作後，<b>可透過備份來復原所有文章和啟用狀態</b>。\n\n但是，純純寫作<b>預設不會自動進行雲端備份</b>，若要啟用自動雲端備份，<b>您需要設定雲端備份帳號</b>，在 純純寫作 - 設定 - 備份 頁面可選擇雲備份類型和設定<b>雲端備份帳號</b>。\n\n純純寫作雲端備份支援 WebDAV / 堅果雲和 Dropbox 網路硬碟。\n\n<b>雲端備份非常重要，若您不設定雲端備份，則萬一手機丟失、損壞、清除資料、復原出廠設定，都將失去您所有寶貴的創作內容！請務必設定雲端備份，確保萬無一失。</b></string>
-  <string name="lineSpacing">行間距</string>
+  <string name="backupReadme">純純寫作支援本機備份和雲端備份，本機備份是自動進行的，當您重灌純純寫作後，<b>可透過備份來復原所有文章和啟用狀態</b>。\n\n但是，純純寫作<b>預設不會自動進行雲端備份</b>，若要啟用自動雲端備份，<b>您需要設定雲端備份帳號</b>，在 純純寫作 - 設定 - 備份 頁面可選擇雲備份類型和設定<b>雲端備份帳號</b>。\n\n純純寫作雲端備份支援 WebDAV / 堅果雲和 Dropbox 網路硬碟。\n\n<b>雲端備份非常重要，若您不設定雲端備份，則萬一手機丟失、損壞、清除資料、恢復原廠設定，都將失去您所有寶貴的創作內容！請務必設定雲端備份，確保萬無一失。</b></string>
+  <string name="lineSpacing">列間距</string>
   <string name="tipParagraphSpacingInMD">Markdown 模式下不會啟用段落間距</string>
   <string name="defaultX">預設</string>
   <string name="zoomIn">放大</string>
   <string name="zoomOut">縮小</string>
-  <string name="switchingBooksTooltip">提示：單擊頂部的書名將可以切換書</string>
+  <string name="switchingBooksTooltip">提示：點按頂部的書名將可以切換書</string>
   <string name="scrollToTheCurrentArticle">滾動到當前文章</string>
   <string name="allBooks">全部書</string>
   <string name="outline">大綱</string>
@@ -329,7 +329,7 @@
   <string name="currentText">目前正文</string>
   <string name="hideSoftKeyboard">收起小鍵盤</string>
   <string name="transparentTopBar">透明頂部列</string>
-  <string name="transparentNavigationBarWarning">這是一個實驗性特性，開啟它之後，可能導致螢幕小鍵盤高度檢查不正確，進而導致快速輸入列無法顯示和文字聚焦失常，如果遇到這些問題，請關閉此選項。</string>
+  <string name="transparentNavigationBarWarning">這是一個實驗性特性，開啟後可能導致螢幕小鍵盤高度檢查不正確，進而導致快速輸入列無法顯示和文字聚焦失常，如果遇到這些問題，請關閉此選項。</string>
   <string name="transparentNavigationBar">透明虛擬導覽列</string>
   <string name="titleAsAWordForACountSummary">開啟此項後，下一項「字數統計模式」將無效，如果想使用「字數統計模式」中的選項，請關閉此項。</string>
   <string name="customFont">自訂字型</string>
@@ -337,12 +337,12 @@
   <string name="corruptBackupTip">該備份檔案已損壞！請嘗試復原其它備份，選擇正確大小和時間的備份！</string>
   <string name="leftMargin">左邊距</string>
   <string name="rightMargin">右邊距</string>
-  <string name="spacingsAndMargins">行間距\n左右邊距</string>
+  <string name="spacingsAndMargins">列間距\n左右邊距</string>
   <string name="autoBackupAndCloudBackupGuide">《自動備份與雲端備份教學》</string>
-  <string name="bridgeSummary">這個功能非常難以理解和使用，不推薦啟用它。</string>
-  <string name="messageCancelBridgeFeature">從這個版本開始，原有的「雲端存取」功能被預設隱藏了，因為每天有許多使用者回饋告訴我他們不知道這個功能是什麼意思，非常抱歉給大家帶來困擾！但同時我也因為回復這些回饋花費了大量時間精力——它們本該用於開發和打磨這個產品。所以目前這個功能預設關閉，如果你喜歡和依賴它，你可以進入備份設定頁面底部，將可以看到一個選項來開啟它。請諒解，非常感謝！</string>
+  <string name="bridgeSummary">這個功能非常難以理解和使用，不推薦將其啟用。</string>
+  <string name="messageCancelBridgeFeature">從這個版本開始，原有的「雲端存取」功能被預設隱藏了，因為每天有許多使用者回報說他們不知道這個功能是什麼意思，非常抱歉給大家帶來困擾！但同時我也因為回覆這些意見花費了大量時間精力——它們本該用於開發和打磨這個產品。所以目前這個功能預設關閉，如果你喜歡和依賴它，你可以進入備份設定頁面底部，將可以看到一個開啟本功能的選項。請諒解，非常感謝！</string>
   <string name="followingBackupsAre">以下是安裝目前版本之前的備份</string>
-  <string name="logInToCloudStorage">登入 WebDAV, Dropbox 或 GoogleDrive</string>
+  <string name="logInToCloudStorage">登入 WebDAV, Dropbox 或 Google Drive</string>
   <string name="scrollToBottom">聚焦到文末</string>
   <string name="textColor">編輯器字型顏色</string>
   <string name="textColorSummary">須知：當切換稿紙後，字型顏色會自動復原到預設顏色。</string>
@@ -353,47 +353,47 @@
   <string name="collapseAllCategories">收起所有卷</string>
   <string name="showMore">顯示更多</string>
   <string name="textColorAlpha">字型顏色透明度</string>
-  <string name="desktopDialogGuide">您需要從\nhttps://writer.drakeet.com/desktop_zh \n下載<b><i>純純寫作桌面版1.5.2 或以上版本</i></b>。\n\n當手機與電腦<b>處於同一個 Wi-Fi 網路或行動基站台</b>時👈👈👈，打開桌面版後將以下的 IP 位址<b>輸入於桌面版中的輸入列中</b>，即可與桌面版即時連線，雙向同步編輯目前文章。</string>
-  <string name="desktopDialogNote">注意：目前純純寫作桌面版還處於非常初期階段，許多功能未完善，請您理解和靜待其後續更新。\n* 若您看到<b>多行 IP 位址</b>，請逐一嘗試連結它們。</string>
-  <string name="tipNotSupportThisDesktopVersion">目前手機端和桌面端版本不匹配，無法連結，請各自更新到最新版後重試</string>
-  <string name="connect">連結</string>
-  <string name="connectDesktop">連結純純寫作桌面版</string>
-  <string name="connectionIsStopping">仍然在斷開連結中，請稍後重試！</string>
-  <string name="disconnectDesktop">斷開與桌面版的連結</string>
+  <string name="desktopDialogGuide">您需要從\nhttps://writer.drakeet.com/desktop_zh \n下載<b><i>純純寫作桌面版1.5.2 或以上版本</i></b>。\n\n當手機與電腦<b>處於同一個 Wi-Fi 網路或行動基站台</b>時👈👈👈，打開桌面版後將以下的 IP 位址<b>輸入至桌面版中的輸入列中</b>，即可與桌面版即時連線，雙向同步編輯目前文章。</string>
+  <string name="desktopDialogNote">注意：目前純純寫作桌面版還處於非常初期階段，許多功能未完善，請您理解和靜待其後續更新。\n* 若您看到<b>多列 IP 位址</b>，請逐一嘗試進行連接。</string>
+  <string name="tipNotSupportThisDesktopVersion">目前手機端和桌面端版本不匹配，無法連接，請各自更新到最新版後重試</string>
+  <string name="connect">連接</string>
+  <string name="connectDesktop">連接純純寫作桌面版</string>
+  <string name="connectionIsStopping">仍然在斷開連接中，請稍後重試！</string>
+  <string name="disconnectDesktop">斷開與桌面版的連接</string>
   <string name="linksCard" translatable="false">純純寫作 - 願文字帶我們穿越時光，連結過去，遙想未來\nhttps://writer.drakeet.com</string>
   <string name="createShortcutLabel">建立快速輸入項</string>
   <string name="cursorPositionForNewArticle">新文章的游標位置</string>
-  <string name="stop_waiting_connection">停止等待連結</string>
+  <string name="stop_waiting_connection">停止等待連接</string>
   <string name="undoValidTip">目前聚焦的輸入列已無法再進一步「復原」了，您可以嘗試從右上角的「歷史記錄」選單中復原您的內容。</string>
-  <string name="desktopConnected">已成功連結桌面版</string>
-  <string name="desktopDisconnected">已斷開連結桌面版</string>
+  <string name="desktopConnected">已成功連接桌面版</string>
+  <string name="desktopDisconnected">已斷開連接桌面版</string>
   <string name="double11Title">11·11 限時半價活動</string>
   <string name="double11Message">在 11 月 10 日至 11 月 12 日期間購買純純寫作進階版，<b>只需要半價即可</b>。非常感謝！</string>
-  <string name="toDoCloudBackupButton">去設定雲備份（雲端備份非常簡單，一勞永逸，萬無一失）</string>
+  <string name="toDoCloudBackupButton">去設定雲端備份（雲端備份非常簡單，一勞永逸，萬無一失）</string>
   <string name="ignoreCloudBackupCheckBox">我不想設定雲端備份，不要再提示我。我甘願承受沒有雲端備份帶來的一切後果，包括因沒有雲端備份而在手機損壞或遺失或刷機時失去我所有的寶貴文章！</string>
   <string name="addChapterAboveThis">在此之上插入新篇章</string>
   <string name="addChapterBelowThis">在此之下插入新篇章</string>
   <string name="selectMore">選取更多</string>
   <string name="moveToOtherBook">移動到其他書</string>
-  <string name="autoInsertBlankLineWhenWrapping">換行時自動插入空行</string>
-  <string name="paragraphSpacingSettingSummary">關閉段間距後，對於超長文字將獲得更好的效能</string>
-  <string name="onlyAvailableWhenParagraphOff">僅在關閉段間距時有效</string>
+  <string name="autoInsertBlankLineWhenWrapping">換行時自動插入空列</string>
+  <string name="paragraphSpacingSettingSummary">關閉段落間距後，對於超長文字將取得更好的效能</string>
+  <string name="onlyAvailableWhenParagraphOff">僅在關閉段落間距時有效</string>
   <string name="markdownAsDefault">Markdown 作為建立文章預設模式</string>
-  <string name="needToPayForMarkdownRenderer">這是 Markdown 快捷預覽頁面，它需要您付費取得純純寫作進階版後才能使用。</string>
+  <string name="needToPayForMarkdownRenderer">這是 Markdown 快速預覽頁面，此功能需要您付費取得純純寫作進階版後才能使用。</string>
   <string name="fabContextCreateNewAfterCurrent">在 目前文章之後 插入新文章</string>
   <string name="fabContextCreateNewAtTheBottom">在 文章列表底部 插入新文章</string>
   <string name="fabContextHideFabUntilNextStart">隱藏這個按鈕直到下次啟動</string>
   <string name="signedIn">已登入</string>
   <string name="notSignedIn">尚未登入</string>
   <string name="latex">LaTeX</string>
-  <string name="syntaxHighlighting">MD 代碼高亮</string>
+  <string name="syntaxHighlighting">MD 程式碼高亮</string>
   <string name="forgetPassword">忘記密碼?</string>
   <string name="emailAddress">電子郵件地址</string>
   <string name="password">密碼</string>
   <string name="nightMode">夜間模式</string>
   <string name="unlimitedWords">無限字數</string>
   <string name="neverLost">從未遺失</string>
-  <string name="supportParagraphSpacing">獨家支援段間距</string>
+  <string name="supportParagraphSpacing">獨家支援段落間距</string>
   <string name="keyboardStateRestoring">鍵盤狀態復原</string>
   <string name="greatCursorFocus">精妙的游標聚焦</string>
   <string name="crazyUpdateBetterAndBetter">瘋狂開發，越來越好</string>
@@ -403,22 +403,22 @@
   <string name="signUpOrSignIn">註冊或登入</string>
   <string name="emailAddressIsEmptyOrIllegal">郵件地址為空或不合法</string>
   <string name="passwordMustBeAtLeast6Characters">密碼長度不能少於 6 位</string>
-  <string name="helperTextForNewAccount">這是一個全新帳號，如果最終確定，我們將為您註冊它</string>
-  <string name="notYetActivated">尚未啟用</string>
-  <string name="notYetActivatedOrExpired">尚未啟用或已過期</string>
+  <string name="helperTextForNewAccount">這是一個全新帳號，如果最終確定，我們將為您進行註冊</string>
+  <string name="notYetActivated">尚未啟動</string>
+  <string name="notYetActivatedOrExpired">尚未啟動或已逾期</string>
   <string name="requiresAtLeast6Characters">需要至少六位字元</string>
   <string name="customPapers">自訂稿紙\n精緻、沉浸</string>
   <string name="markdownQuickPreview">Markdown 快速預覽</string>
   <string name="exportToPicMdTxt">儲存為、匯出為長圖片、md、txt</string>
   <string name="materialDesign2ThemeWithLineBreak">Material Design 2\n主題</string>
   <string name="veryVerySmooth">非常非常順暢</string>
-  <string name="helperTextForRegisteredAccount">這個帳號已註冊，如果最終確定，我們將為你登入它</string>
-  <string name="messageCustomFontAndPro">檢查到您正在使用「自訂字型」功能，該功能需要付費獲得純純寫作 Pro 才能使用，您可以點擊確定來獲得純純寫作 Pro 以及更多進階版功能，或者點擊取消自訂字型（下次啟動時生效）。</string>
+  <string name="helperTextForRegisteredAccount">這個帳號已被註冊，如果最終確定，我們將為你進行登入</string>
+  <string name="messageCustomFontAndPro">檢查到您正在使用「自訂字型」功能，該功能需要付費獲得純純寫作 Pro 才能使用，您可以點選確定以取得純純寫作 Pro 以及更多進階版功能，或者點選取消自訂字型（下次啟動時生效）。</string>
   <string name="signingInIsInvalid">登入失效</string>
-  <string name="verificationCode">驗證碼</string>
+  <string name="verificationCode">確認代碼</string>
   <string name="emailOrPasswordIsIncorrect">郵件或密碼不正確</string>
-  <string name="messageNeedToPay">這是進階版功能，您需要先<b>登入</b>或付費取得純純寫作 Pro 才能使用它，點擊確定即可了解純純寫作所有進階版功能。\n\n當您取得純純寫作 Pro 後，您可以使用所有的進階版功能。</string>
-  <string name="license">啟用碼</string>
+  <string name="messageNeedToPay">這是進階版功能，您需要先<b>登入</b>或付費取得純純寫作 Pro 才能使用它，點選確定即可了解純純寫作所有進階版功能。\n\n當您取得純純寫作 Pro 後，您可以使用所有的進階版功能。</string>
+  <string name="license">啟動序號</string>
   <string name="ProIntroductionMarkdown"><![CDATA[
 |        #### 自訂稿紙
 |
@@ -434,7 +434,7 @@
 |
 |        #### 儲存為長圖片 / md / txt 檔案
 |
-|        您可以將文章另存為長圖片或 .md .txt 檔案：
+|        您可以將文章儲存為長圖片或 .md .txt 檔案：
 |
 |        ![圖片](https://gitee.com/PureWriter/resources/raw/master/pro/2.webp)
 |
@@ -452,7 +452,7 @@
 |
 |        #### Material Design 2 主題
 |
-|        開啟 Material Design 2 主題後，您將獲得透明化的頂部列，它不再是純黑色的，這可以獲得更加沉浸式的精美 UI：
+|        開啟 Material Design 2 主題後，您將取得透明化的頂部列，它不再是純黑色的，這可以得到更加沉浸式的精美 UI：
 |
 |        ![圖片](https://gitee.com/PureWriter/resources/raw/master/pro/5.webp)
 |
@@ -460,18 +460,18 @@
 |
 |        ![Pure Writer Desktop](https://gitee.com/PureWriter/resources/raw/master/pro/PureWriterDesktop.webp)
 |
-|        你可以在純純寫作首頁頂部的雲圖示選單 ☁️ 裡找到 純純寫作桌面版 的下載連結和連線桌面版。
+|        你可以在純純寫作首頁頂部的雲端圖示選單 ☁️ 裡找到 純純寫作桌面版 的下載連結並連接桌面版。
 |
-|        目前，純純寫作桌面版仍然還在 alpha 階段，它十分初級，只提供了與手機雙向即時瞬間同步寫作功能。
+|        目前，純純寫作桌面版仍然還在 alpha 階段，它十分初級，只提供了與手機雙向即時同步寫作功能。
 |
-|        開發桌面版需要花費巨大的精力和時間，而且純純寫作計畫在之後重新實現一個完整的更好的桌面版。您的支援將會是我們巨大的動力，非常感謝！
+|        開發桌面版需要花費巨大的精力和時間，而且純純寫作計畫在之後重新實現一個完整的更好的桌面版。您的支持將會是我們巨大的動力，非常感謝！
     ]]></string>
-  <string name="messageThankYouForYourSupport">您的支持能夠讓純純寫作更好地堅持開發下去，使我們一直堅持好的方向，良心的產品，並且激勵更多的獨立開發者。\n\n純純寫作因為您的支持而能夠不斷更新、完善，非常感謝！</string>
+  <string name="messageThankYouForYourSupport">您的支持能夠讓純純寫作更好地堅持開發下去，使我們一直堅持好的方向，良心的產品，並且激勵更多的獨立開發人員。\n\n純純寫作因為您的支持而能夠不斷更新、完善，非常感謝！</string>
   <string name="buyPureWriterPro"><b>購買純純寫作</b> Pro</string>
   <string name="tipMarkdownQuickPreview">橫向滑動到下一個頁面\n可以進行 Markdown 快速預覽</string>
   <string name="expiresOn">到期日</string>
   <string name="lifetime">有效期至永久</string>
-  <string name="proExpired">會員已過期</string>
+  <string name="proExpired">會員已逾期</string>
   <string name="changelog">更新日誌</string>
   <string name="advancedReadOnlyMode">進階唯讀模式</string>
   <string name="fabContextCreateNewAtTheBottomOfCurrentCategory">在 目前卷末尾 插入新文章</string>
@@ -481,18 +481,18 @@
   <string name="savedStateModeEnableAll">無論如何，對所有文章啟用</string>
   <string name="savedStateModeDisableAll">無論如何，對所有文章禁用</string>
   <string name="summaryScrollToBottom">是否在首頁顯示這個按鈕</string>
-  <string name="cloudBackupFailed">雲端備份失敗，可能的原因：\n* 如果您在下方看到 timeout 文字，說明目前網路連線逾時，請檢查網路連線後重新開啟純純寫作即可自動重新備份\n* 如果您的雲端儲存空間滿了，或者本月上傳流量用完了，這也將導致備份失敗，請去檢查它再重試 \n* 如果一切操作都無法解決，請嘗試在純純寫作雲端備份頁面退出您的雲端備份帳號並重新登入它\n\n具體錯誤訊息</string>
-  <string name="dropboxBackupFailed">您的 Dropbox 雲端備份失敗，請嘗試在純純寫作雲端備份頁面退出您的 Dropbox 帳號並重新登入它</string>
+  <string name="cloudBackupFailed">雲端備份失敗，可能的原因：\n* 如果您在下方看到 timeout 文字，說明目前網路連線逾時，請檢查網路連線後重新開啟純純寫作即可自動重新備份\n* 如果您的雲端儲存空間滿了，或者本月上傳流量用盡，這也將導致備份失敗，請去檢查後再重試 \n* 如果一切操作都無法解決，請嘗試在純純寫作雲端備份頁面退出您的雲端備份帳號並重新登入\n\n詳細錯誤資訊</string>
+  <string name="dropboxBackupFailed">您的 Dropbox 雲端備份失敗，請嘗試在純純寫作雲端備份頁面退出您的 Dropbox 帳號並重新登入</string>
   <string name="dropboxBackupFailedDueToInsufficientSpace">雲端備份失敗：Dropbox 儲存空間不足</string>
-  <string name="tipImageDialog">請在下面輸入您要插入的網路圖片連結。\n或者您可以點擊左下角的「本機圖片」來選取本機圖片並自動取得此圖片的本機連結。</string>
+  <string name="tipImageDialog">請在下面輸入您要插入的網路圖片連結。\n或者您可以點按左下角的「本機圖片」來選取本機圖片並自動取得此圖片的本機連結。</string>
   <string name="imageUrl">圖片連結</string>
   <string name="imageDesc">圖片描述（可不填）</string>
   <string name="width">寬度</string>
   <string name="insertMarkdownImage">插入 Markdown 圖片</string>
   <string name="pureWriterDesktop">純純寫作\n桌面版</string>
   <string name="moreAndBetter">愈來愈多\n愈來愈好</string>
-  <string name="clickBottomAddNewBlankLine">點擊編輯器底部空白區域自動插入空行</string>
-  <string name="summaryClickBottomAddNewBlankLine">如果最後一行不是空行，則當點擊編輯器底部空白區域時，自動在文末插入一新的空行並聚焦。</string>
+  <string name="clickBottomAddNewBlankLine">點按編輯器底部空白區域自動插入空列</string>
+  <string name="summaryClickBottomAddNewBlankLine">如果最後一列不是空白，則當點按編輯器底部空白區域時，自動在文末插入一新的空列並聚焦。</string>
   <string name="deleteCompletely">徹底刪除</string>
   <string name="regex">正規表示式</string>
   <string name="searchArticles">搜尋文章 / 快速跳轉到某文章</string>
@@ -516,14 +516,14 @@
 |        您也可以透過查閱這個 [文件頁面](https://docs.oracle.com/javase/tutorial/i18n/format/simpleDateFormat.html) 中的 **表格** 來取得更多 **時間格式字元** 並自由組合。
     ]]></string>
   <string name="read">檢視</string>
-  <string name="introductionOfReadOnlyMode">* 當游標不可見時，需要雙擊編輯器才能置入游標並進入編輯模式\n* 當游標可見時，無論何時，只需單擊即可編輯或修改游標位置\n* 當游標可見 且 螢幕小鍵盤已收起時，可以按「返回鍵」來隱藏游標並進入唯讀模式</string>
-  <string name="messageReadOnlyModeAndPro">這個「進階唯讀模式」需要純純寫作 Pro，你可以點擊確定進入純純寫作 Pro 介紹頁面和取得更多進階版功能，或者點擊取消（將在下次啟動後自動取消「進階唯讀模式」）。</string>
+  <string name="introductionOfReadOnlyMode">* 當游標不可見時，需要點按兩次編輯器才能置入游標並進入編輯模式\n* 當游標可見時，無論何時，只需點按即可編輯或修改游標位置\n* 當游標可見 且 螢幕小鍵盤已收起時，可以按「返回鍵」來隱藏游標並進入唯讀模式</string>
+  <string name="messageReadOnlyModeAndPro">這個「進階唯讀模式」需要純純寫作 Pro，你可以點選確定進入純純寫作 Pro 介紹頁面和取得更多進階版功能，或者點選取消（將在下次啟動後自動取消「進階唯讀模式」）。</string>
   <string name="doNotRemindAgain">不再提示</string>
   <string name="homeFab">首頁右下角浮動按鈕</string>
-  <string name="fabOverflowModeSingleClick">單擊打開二級選單，在二級選單中可選擇建立文章，避免誤觸</string>
-  <string name="fabOverflowModeLongPress">單擊即可直接建立文章，而長按才打開二級選單</string>
+  <string name="fabOverflowModeSingleClick">點按開啟二級選單，在二級選單中可選擇建立文章，避免意外操作</string>
+  <string name="fabOverflowModeLongPress">點按即可直接建立文章，而長按才開啟二級選單</string>
   <string name="safeMode">安全模式</string>
-  <string name="summarySafeMode">當純純寫作進入後台或最近工作清單頁面，將模糊化其頁面內容；開啟此項後將同時<b>禁止在應用程式內截圖</b>！</string>
+  <string name="summarySafeMode">當純純寫作進入背景運作或最近工作清單頁面，將模糊化其頁面內容；開啟此項後將同時<b>禁止在應用程式內截圖</b>！</string>
   <string name="pressBackToClearCursor">已隱藏游標並進入唯讀模式</string>
   <string name="PureWriterManual">《純純寫作使用手冊》</string>
   <string name="tipBlueInputBox">提示：輸入完成後，按確認鍵 ⏎ 可跳出藍色的填充框</string>
@@ -546,51 +546,51 @@
   <string name="timeCreated">建立時間</string>
   <string name="timeCreatedAndModified">建立 + 更新時間</string>
   <string name="presetFreeFont">免費的內建霞鶩文楷</string>
-  <string name="summaryPresetFreeFont">僅在<b>未</b>啟用「自訂字型」時有效。\n如果取消勾選此選項，純純寫作將會使用<b>系統原生字體</b>或下方您自訂的字體。</string>
+  <string name="summaryPresetFreeFont">僅在<b>未</b>啟用「自訂字型」時有效。\n如果取消選取此選項，純純寫作將會使用<b>系統原生字型</b>或下方您自訂的字型。</string>
   <string name="editor1">第一編輯器</string>
   <string name="editor2">第二編輯器</string>
   <string name="currentChapterWordCount">目前章節字數</string>
   <string name="currentBookWordCount">全書字數</string>
   <string name="cursorJoyTutorial">按住這個搖晃的按鈕並移動手指，即可控制游標移動</string>
-  <string name="openArticleListAfterSwitchingBooks">切換書籍後開啟側邊欄文章清單</string>
+  <string name="openArticleListAfterSwitchingBooks">切換書籍後開啟側邊列文章清單</string>
   <string name="useLegacyRender">使用舊版繪製器</string>
   <string name="wordsShort">字</string>
-  <string name="rating">給予好評</string>
-  <string name="splitLayout">分欄</string>
+  <string name="rating">給予正評</string>
+  <string name="splitLayout">分列</string>
   <string name="thankYou">非常感謝！</string>
   <string name="theTry">試用</string>
   <string name="selectFolder">選擇資料夾</string>
-  <string name="fileTypeNotSupported">不支援該文件類型</string>
+  <string name="fileTypeNotSupported">不支援該檔案類型</string>
   <string name="grantStoragePermission">授予純純寫作資料夾權限</string>
-  <string name="folderNoLongerExists">該資料夾或儲存不再存在！</string>
+  <string name="folderNoLongerExists">該資料夾或儲存空間已不存在！</string>
   <string name="tipNotRecommendedFolder">這個目錄不符合我們推薦的目錄，將導致純純寫作無法讀取到它舊有的備份資料，請知悉或返回上一步進行更正！</string>
   <string name="tipTargetFolder">"根據您選擇的資料夾，純純寫作的最終儲存目錄為: "</string>
-  <string name="messageWhyNeedSAF">為了更好地保護使用者隱私，從 Android 11 開始，純純寫作**不再需要全盤讀寫權限**，取而代之的是讓**使用者指定一個資料夾目錄**，純純寫作將僅對於該目錄擁有讀寫權限。\n\n因此，您需要點擊下方的按鈕選取一個資料夾目錄，為了方便以後重新安裝時能夠對接舊有資料，我們**強烈建議**您固定選擇 ***`Documents`*** 這個資料夾 🙏</string>
+  <string name="messageWhyNeedSAF">為了更好地保護使用者隱私，從 Android 11 開始，純純寫作**不再需要全部檔案存取權限**，取而代之的是讓**使用者指定一個資料夾目錄**，純純寫作將僅對於該目錄擁有讀寫權限。\n\n因此，您需要點按下方的按鈕選取一個資料夾目錄，為了方便以後重新安裝時能夠對接舊有資料，我們**強烈建議**您固定選擇 ***`Documents`*** 這個資料夾 🙏</string>
   <string name="selectFont">選取字型</string>
   <string name="pureWriterFolder">純純寫作資料夾</string>
-  <string name="materialFilesNote">目前下方的「打開」僅支援使用 zhanghai/MaterialFiles 打開，如果需要您可以自行下載這個應用，或者手動使用您系統中的檔案管理器打開上述路徑。</string>
-  <string name="changeFolder">更換資料夾</string>
+  <string name="materialFilesNote">目前下方的「開啟」僅支援使用 zhanghai/MaterialFiles 開啟，如果需要您可以自行下載這個應用程式，或者手動使用您系統中的檔案管理員開啟上述路徑。</string>
+  <string name="changeFolder">變更資料夾</string>
   <string name="yourFolderIs">"您選擇的資料夾目錄為: "</string>
-  <string name="changeFolderNote">如果您選擇下方的「*更換資料夾*」，您需要**先手動**到上述資料夾目錄去把 PureWriter 資料夾移動到新的目標資料夾，然後再進行更換。</string>
+  <string name="changeFolderNote">如果您選擇下方的「*變更資料夾*」，您需要**先手動**到上述資料夾目錄中將 PureWriter 資料夾移動到新的目標資料夾，然後再進行變更。</string>
   <string name="previous">上一步</string>
-  <string name="customFontTipForAndroid11">Android 11 以上系統需要每次點擊下方的選項選取字體檔案才能使之生效</string>
-  <string name="youNeedToSignInAgain">您需要重新登錄</string>
+  <string name="customFontTipForAndroid11">Android 11 以上系統需要每次點按下方的選項選取字型檔案才能使之生效</string>
+  <string name="youNeedToSignInAgain">您需要重新登入</string>
   <string name="desktopLink">https://writer.drakeet.com/desktop_zh</string>
   <string name="autoConnectToDesktopNextTime">下次自動連接到桌面版</string>
   <string name="autoConnectToDesktop">自動連接到桌面版</string>
   <string name="optionsForTheFewPeople">少數派選項</string>
-  <string name="summaryPie">或稱強迫症選項，提供一些本不該提供的配置項</string>
+  <string name="summaryPie">或稱強迫症選項，提供一些本不該提供的設定項</string>
   <string name="stretchEdgeEffect">編輯器滾動到邊緣的彈性動畫</string>
   <string name="staticCursor">靜態游標（不要閃爍）</string>
   <string name="cursorJoyModePosition">「移動游標」模式和位置</string>
   <string name="cursorJoyModePosition0">防誤觸模式，在右側</string>
-  <string name="cursorJoyModePosition1">「可直接觸摸移動」模式，在快捷輸入列表裡</string>
-  <string name="typewriterModeMode0">「突顯目前段落、淡化其他段落」模式</string>
-  <string name="typewriterModeMode1">「突顯目前行、淡化其他行」模式</string>
-  <string name="restoreOptionsMessage">您需要使用這個備份來覆蓋本機內容？還是合併加入本機內容？\n\n注意：若您選擇「合併」，那麼存在於備份文件中的設定項和雲備份帳號訊息將不會被合併，您可能需要重新手動配置它們。\n\n另外，您如果修改了文章順序或者刪除文章，這些操作也不會被合併，因為這會引起衝突。<b>因此我們更建議您使用「覆蓋」，並且若在一個裝置上修改了資料後應該立即在另一個裝置上透過「覆蓋」把資料同步過去。</b></string>
+  <string name="cursorJoyModePosition1">「可直接觸摸移動」模式，在快速輸入清單中</string>
+  <string name="typewriterModeMode0">「突出顯示目前段落、淡化其他段落」模式</string>
+  <string name="typewriterModeMode1">「突出顯示目前列、淡化其他列」模式</string>
+  <string name="restoreOptionsMessage">您需要使用這個備份來覆蓋本機內容？還是合併加入本機內容？\n\n注意：若您選擇「合併」，那麼存在於備份檔案中的設定項和雲備份帳號資訊將不會被合併，您可能需要重新手動進行配置。\n\n另外，您如果修改了文章順序或者刪除文章，這些操作也不會被合併，因為這會引起衝突。<b>因此我們更建議您使用「覆蓋」，並且若在一個裝置上修改了資料後應該立即在另一個裝置上透過「覆蓋」把資料同步過去。</b></string>
   <string name="merge">合併</string>
   <string name="merging">合併中…</string>
-  <string name="checkIntegrityOfBackup">檢查備份文件完整性…</string>
+  <string name="checkIntegrityOfBackup">檢查備份檔案完整性…</string>
   <string name="noteBeforeRestoringBackup">在一切開始前，對目前資料進行一次備份…</string>
   <string name="startMerging">開始合併…</string>
   <string name="insertANewBook">插入新的書</string>
@@ -600,7 +600,7 @@
   <string name="summary">摘要</string>
   <string name="updateAnExistingArticle">更新已有的文章</string>
   <string name="totalNumberOfArticlesInsertedOrUpdated">總共插入或更新的文章數目</string>
-  <string name="insertANewShortcut">插入新的快捷輸入項</string>
+  <string name="insertANewShortcut">插入新的快速輸入項</string>
   <string name="totalNumberOfNewTimeMachineMessagesInserted">總插入新的時光機訊息數目</string>
   <string name="mergeDone">合併完成！</string>
   <string name="relaunch">重啟</string>
@@ -608,70 +608,70 @@
   <string name="autoCompleteSummary">自動補全成對符號僅當游標在文章<b>末尾</b>時</string>
   <string name="autoDeleteSymbolsInPairs">自動成對刪除符號</string>
   <string name="autoDeleteSymbolsInPairsSummary">僅當成對符號中的內容<b>為空</b>時才會進行成對地刪除</string>
-  <string name="editor2Tip">您正處在第二編輯器中，它的頂部圖示和第一編輯器是位置相反的。如果您希望回到第一編輯器，您可以<b>在編輯器上向左或向右划動</b>即可。</string>
-  <string name="shortcutKeysForShortcut">快捷輸入項的快捷鍵</string>
-  <string name="shortcutKeysForShortcutSummary">在外接鍵盤上按 Alt 或 Ctrl 鍵加數字可以呼叫快捷輸入項</string>
-  <string name="optionsForLandscape">平板設定項和指引</string>
+  <string name="editor2Tip">您正處在第二編輯器中，它的頂部圖示和第一編輯器是位置相反的。如果您希望回到第一編輯器，您可以<b>在編輯器上向左或向右滑動</b>即可。</string>
+  <string name="shortcutKeysForShortcut">快速輸入項的快速鍵</string>
+  <string name="shortcutKeysForShortcutSummary">在外掛式鍵盤上按 Alt 或 Ctrl 鍵加數字可以呼叫快速輸入項</string>
+  <string name="optionsForLandscape">平板電腦設定項和指引</string>
   <string name="editInVerticalCenter">垂直居中編輯</string>
-  <string name="onlyWorkForHardwareKeyboard">僅在使用外接鍵盤時生效</string>
-  <string name="editInVerticalCenterSummary">使得当前编辑的行总是在屏幕垂直中央（可能无效，这属于输入法的问题，请见谅）</string>
+  <string name="onlyWorkForHardwareKeyboard">僅在使用外掛式鍵盤時生效</string>
+  <string name="editInVerticalCenterSummary">使得當前編輯的列總是處於螢幕垂直中央（可能無效，這屬於輸入法的問題，請見諒）</string>
   <string name="migrateImageAssets">遷移 Markdown 圖片資源到 Documents/PureWriter/Assets 目錄下</string>
-  <string name="migrateImageAssetsSummary">這有助於您集中地轉移您的所有 Markdown 引用到的圖片到您的新裝置上，您可以在此操作後，將 Documents/PureWriter/Assets 資料夾複製到新裝置同樣目錄上，然後再復原此裝置的備份到新裝置上，這樣新裝置就可以順利地引用到原來的圖片了。</string>
-  <string name="tipForFromPlayToAlipay">使用該付費方式，請確保您身處中國大陸，這個付費方式原則上僅是提供給中國大陸使用者使用，因為在中國無法使用 Google 和 Google Play 付費。</string>
+  <string name="migrateImageAssetsSummary">這有助於您集中地轉移您的所有 Markdown 引用的圖片到您的新裝置上，您可以在此操作後，將 Documents/PureWriter/Assets 資料夾複製到新裝置相同目錄中，然後再復原此裝置的備份到新裝置上，這樣新裝置就可以順利地引用到原來的圖片了。</string>
+  <string name="tipForFromPlayToAlipay">使用此付費方式，請確保您身處中國大陸，這個付費方式原則上僅是提供給中國大陸使用者使用，因為在中國無法使用 Google 和 Google Play 付費。</string>
   <string name="switchToAlipayPaymentMethod">切換為支付寶付費方式</string>
   <string name="switchToGooglePlayPaymentMethod">切換為 Google Play 付費方式</string>
   <string name="askUnsubscribe"><u>取消訂閱？</u></string>
-  <string name="notesForGoogleSkus">重要說明:\n\n* 由於 Google 並沒有提供取消訂閱的介面給應用，因此如果您需要取消訂閱，您需要自行點擊您的訂閱項目或者上方的「取消訂閱？」按鈕進行操作。\n\n* 當您在 Google Play 取消本應用的訂閱後，本應用並不能立即接收到最新狀態，因此您將會看到該訂閱項在本頁面中仍然處於「有效」狀態，這是正常現象，一般到第二天會得到正確結果，或等到目前訂閱週期結束。\n\n* 如果您打算從訂閱項目轉為「終身」項目，您應該先取消您的訂閱項，再購買「終身」項目，本應用無法自行取消您的訂閱項。\n\n* 如果您在付費過程中遇到 DF-DFERH-01 錯誤，請嘗試重啟您的裝置後重試即可。\n\n* 付費結果將自動綁定到您的系統 Google 帳號上，感謝支援！</string>
+  <string name="notesForGoogleSkus">重要說明:\n\n* 由於 Google 並沒有提供取消訂閱的介面給應用程式，因此如果您需要取消訂閱，您需要自行點選您的訂閱項目或者上方的「取消訂閱？」按鈕進行操作。\n\n* 當您在 Google Play 取消本應用程式的訂閱後，本應用並不能立即接收到最新狀態，因此您將會看到該訂閱項在本頁面中仍然處於「有效」狀態，這是正常現象，一般到第二天會得到正確結果，或等到目前訂閱週期結束。\n\n* 如果您打算從訂閱項目轉為「終身」項目，您應該先取消您的訂閱項，再購買「終身」項目，本應用程式無法自行取消您的訂閱項。\n\n* 如果您在付費過程中遇到 DF-DFERH-01 錯誤，請嘗試重新啟動您的裝置後重試即可。\n\n* 付費結果將自動綁定到您的系統 Google 帳號上，感謝支持！</string>
   <string name="skuActive">有效</string>
   <string name="activating">啟動中…</string>
   <string name="updating">正在更新…</string>
   <string name="themesAndPapers">主題和稿紙</string>
   <string name="once">曾經</string>
-  <string name="selectALightTheme">請選擇一亮色主題</string>
-  <string name="selectADarkTheme">請選擇一暗色主題</string>
+  <string name="selectALightTheme">請選擇一淺色主題</string>
+  <string name="selectADarkTheme">請選擇一深色主題</string>
   <string name="selectATheme">請選擇主題</string>
   <string name="fixedThemeTitle">固定、不自動切換</string>
   <string name="followSystemThemeTitle">跟隨系統自動切換</string>
-  <string name="scheduledThemeTitle">根據時間自動切換：\n7:00 - 17:00 採用亮色，其餘時間暗色</string>
-  <string name="paperSettingsHint">點擊可選擇或自訂稿紙</string>
-  <string name="lightTheme">亮色主題</string>
-  <string name="darkTheme">暗色主題</string>
+  <string name="scheduledThemeTitle">根據時間自動切換：\n7:00 - 17:00 採用淺色，其餘時間深色</string>
+  <string name="paperSettingsHint">點按可選擇或自訂稿紙</string>
+  <string name="lightTheme">淺色主題</string>
+  <string name="darkTheme">深色主題</string>
   <string name="realYes">是</string>
   <string name="realNo">否</string>
-  <string name="whetherOverwriteSettings">是否覆蓋本機設定項和帳戶訊息？</string>
-  <string name="askOverwriteSettings">我們將會使用您的備份文件中的文章資料庫覆蓋本機文章資料庫，但我們不知道您是否需要我們使用備份文件中的配置項覆蓋本機的配置項。請選擇：</string>
-  <string name="privacyPolicySummary">純純寫作不會收集您的任何隱私訊息</string>
+  <string name="whetherOverwriteSettings">是否覆蓋本機設定項和帳戶資訊？</string>
+  <string name="askOverwriteSettings">我們將會使用您的備份檔案中的文章資料庫覆蓋本機文章資料庫，但我們不知道您是否需要我們使用備份檔案中的設定項覆蓋本機設定。請選擇：</string>
+  <string name="privacyPolicySummary">純純寫作不會蒐集您的任何隱私資訊</string>
   <string name="sortingOptions">排序選項</string>
   <string name="modifyOrderOfChapters">修改章節的順序</string>
   <string name="modifyOrderOfCategories">修改卷的順序</string>
-  <string name="saveAsTxtFile">儲存為 .txt 文件</string>
-  <string name="saveAsMdFile">儲存為 .md 文件</string>
+  <string name="saveAsTxtFile">儲存為 .txt 檔案</string>
+  <string name="saveAsMdFile">儲存為 .md 檔案</string>
   <string name="saveAsLongImage">儲存為長圖片(.png)</string>
   <string name="previewThemeSmartisan">主題：仿錘子便簽風格</string>
-  <string name="previewThemeDark">主題：暗色</string>
-  <string name="previewThemeLight">主題：亮色</string>
-  <string name="useAppFont">使用應用字體</string>
-  <string name="useSystemFont">使用系統字體</string>
-  <string name="tipBadThemeBackground">當前選擇的背景圖片或顏色與當前主題的字體顏色不匹配，請重新選擇，如果您認為此提示錯誤，請忽略此提示。</string>
-  <string name="keywordDetection">敏感詞</string>
+  <string name="previewThemeDark">主題：深色</string>
+  <string name="previewThemeLight">主題：淺色</string>
+  <string name="useAppFont">使用應用程式字型</string>
+  <string name="useSystemFont">使用系統字型</string>
+  <string name="tipBadThemeBackground">當前選擇的背景圖片或顏色與當前主題的字型顏色不匹配，請重新選擇，如果您認為此提示錯誤，請忽略此提示。</string>
+  <string name="keywordDetection">敏感字彙</string>
   <string name="confirmDeletion">確認刪除</string>
-  <string name="addAKeyword">新增敏感詞</string>
-  <string name="clearAllKeywords">清空所有敏感詞</string>
-  <string name="pleaseSeeTheKeywordsFile">請見敏感詞文件</string>
+  <string name="addAKeyword">新增敏感字彙</string>
+  <string name="clearAllKeywords">清空所有敏感字彙</string>
+  <string name="pleaseSeeTheKeywordsFile">請見敏感字彙檔案</string>
   <string name="export">匯出</string>
   <string name="import2">匯入</string>
-  <string name="keywordsAreAsFollow">敏感詞內容如下，一行一個</string>
-  <string name="tipEmptyKeywords">目前[敏感詞]庫為空，您可以點擊頂部的添加或匯入按鈕匯入敏感詞，符合敏感詞的文字將會在編輯器中被即時標註出來。</string>
-  <string name="keywordsManagement">敏感詞管理</string>
-  <string name="uploadingKeywordsToCloud">正在上傳敏感詞到雲端...</string>
-  <string name="downloadingKeywordsFromCloud">正在從雲端下載敏感詞...</string>
-  <string name="keywordRetrieval">敏感詞檢索</string>
+  <string name="keywordsAreAsFollow">敏感字彙內容如下，一列一個</string>
+  <string name="tipEmptyKeywords">目前[敏感字彙]庫為空，您可以點按頂部的新增或匯入按鈕加入敏感字彙，符合敏感字彙的文字將會在編輯器中被即時標註出來。</string>
+  <string name="keywordsManagement">敏感字彙管理</string>
+  <string name="uploadingKeywordsToCloud">正在上傳敏感字彙到雲端...</string>
+  <string name="downloadingKeywordsFromCloud">正在從雲端下載敏感字彙...</string>
+  <string name="keywordRetrieval">敏感字彙檢索</string>
   <string name="retrieveCurrentArticle">檢索目前文章</string>
   <string name="previousOne">上一個</string>
   <string name="nextOne">下一個</string>
   <string name="uploadToCloudStorage">上傳到雲端硬碟</string>
   <string name="downloadFromCloudStorage">從雲端硬碟拉取</string>
-  <string name="disableKeywordsFeature">禁用敏感詞功能</string>
+  <string name="disableKeywordsFeature">禁用敏感字彙功能</string>
   <string name="filter">過濾或搜尋</string>
   <string name="limit1080wForPreviewImages">將匯出圖片的最大寬度限制為 1080</string>
 
@@ -694,17 +694,17 @@
   <string name="noteDailyWidgetSetting">在「每日統計」頁面頂部的這片格子區是仿造 GitHub contributions 風格的寫作情況熱力圖。對於格子顏色，除了預設 0 字數級別外，格子顏色有 4 個級別，其中預設最高級別為 2000 字及以上，您可以修改這個最高級別字數作為您的目標：</string>
   <string name="overview">總覽</string>
   <string name="purchaseTime">購買時間</string>
-  <string name="ignoreBatteryOptimizationsTip">關閉電池最佳化以獲得更穩定的桌面版連接（請放心，純純寫作不會產生大量耗電，但系統的電池最佳化功能可能會切斷您的網路連接）</string>
-  <string name="commaToFullStopWhenEnteringANewline">逗號換行自動變句號</string>
-  <string name="hideStatusBar">隱藏狀態欄，更加沉浸和專注</string>
+  <string name="ignoreBatteryOptimizationsTip">關閉電池最佳化以取得更穩定的桌面版連接（請放心，純純寫作不會產生大量耗電，但系統的電池最佳化功能可能會切斷您的網路連線）</string>
+  <string name="commaToFullStopWhenEnteringANewline">逗號在換行後自動變句點</string>
+  <string name="hideStatusBar">隱藏狀態列，更加沉浸和專注</string>
   <string name="hideStatusBarSummary">僅對主頁（編輯器頁面）生效</string>
-  <string name="noNetworkPermission">沒有網路權限 / 無法聯網</string>
-  <string name="noNetworkPermissionMessage">您禁止了純純寫作的聯網權限，導致它無法連接，這將導致您無法登入純純寫作帳號，並且無法進行雲備份，請授予純純寫作網路權限！</string>
-  <string name="hideWordCountOnTM">隱藏在時光機底欄上的字數統計按鈕</string>
-  <string name="tryChangingANiceBackgroundOrTheme">試試更改一個美妙的背景或主題？ </string>
-  <string name="databaseDowngradeErrorMessage">您的純純寫作復原或使用了一個來自更高版本純純寫作的資料庫文件，目前版本的純純寫作無法處理該資料庫，請更新純純寫作到最新版即可解決此問題。\n\n如果不更新，則程式無法正常使用，這並非我們有意想限制您，而是目前舊版在技術上就是無法處理新版的資料庫。請您理解並更新到最新版即可解決。\n\n下載最新版：\nhttps://a.app.qq.com/o/simple.jsp?pkgname=com.drakeet.purewriter\n或者 https://t.me/s/PureWriter</string>
+  <string name="noNetworkPermission">沒有網路權限 / 無法連接網路</string>
+  <string name="noNetworkPermissionMessage">您禁止了純純寫作的網路訪問權限，導致無法進行連線，這將導致您無法登入純純寫作帳號，並且無法進行雲端備份，請授予純純寫作網路權限！</string>
+  <string name="hideWordCountOnTM">隱藏時光機底部列的字數統計按鈕</string>
+  <string name="tryChangingANiceBackgroundOrTheme">試試變更一個美妙的背景或主題？ </string>
+  <string name="databaseDowngradeErrorMessage">您的純純寫作復原或使用了一個來自更高版本純純寫作的資料庫檔案，目前版本的純純寫作無法處理該資料庫，請更新純純寫作到最新版本即可解決此問題。\n\n如果不更新，則程式無法正常使用，這並非我們有意想限制您，而是目前舊版在技術上就是無法處理新版的資料庫。請您理解並更新到最新版本即可解決。\n\n下載最新版本：\nhttps://a.app.qq.com/o/simple.jsp?pkgname=com.drakeet.purewriter\n或者 https://t.me/s/PureWriter</string>
   <string name="databaseDowngradeError">資料庫降級錯誤</string>
-  <string name="forcedPortrait">強制豎屏</string>
-  <string name="forcedPortraitSummary">無論您是否打開自動旋轉，此應用程序都將使用縱向模式。 </string>
-  <string name="titleAsAWordForACountSummary2">一個單字整體算作一個計數，而不是每個字母都算一個計數</string>
+  <string name="forcedPortrait">強制縱向螢幕</string>
+  <string name="forcedPortraitSummary">無論您是否開啟自動旋轉，此應用程式都將使用縱向模式。 </string>
+  <string name="titleAsAWordForACountSummary2">一個英文單字算作一個計數，而不是每個字母都算一個計數</string>
 </resources>


### PR DESCRIPTION
- 大陸的「行」 對應 台灣的「列」；大陸的「列」 對應 台灣的「欄/行」。為了不混誵，故進行調整 (「換行」一詞不受影響)
- 跟從 Android 系統的翻譯，改「亮色」為「淺色」；「暗色」為「深色」
- 調整部分行文，比如去除很多處的「它」，因為在中文裡這個元素很多時候是不必要的
- 對上次翻譯矯枉過正的部分進行還原
- 其他多數跟從 Microsoft Word 繁體中文版的翻譯